### PR TITLE
Execute template into a buffer to avoid partial output and properly catch errors before writing

### DIFF
--- a/app/template.go
+++ b/app/template.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"fmt"
 	htmpl "html/template"
 	"log"
@@ -44,7 +45,15 @@ func renderTemplate(w http.ResponseWriter, r *http.Request, name string, status 
 	if t == nil {
 		return fmt.Errorf("Template %s not found", name)
 	}
-	return t.Execute(w, data)
+
+	// Write to a buffer to properly catch errors and avoid partial output written to the http.ResponseWriter
+	var buf bytes.Buffer
+	err := t.Execute(buf, data)
+	if err != nil {
+		return err
+	}
+	_, err = buf.WriteTo(w)
+	return err
 }
 
 var templates = map[string]*htmpl.Template{}


### PR DESCRIPTION
If executing the template straight into the ResponseWriter the output will be partial on error. Instead we should always write to a bytes.Buffer first and check for errors before actually writing the response.
